### PR TITLE
implement ingress and ServiceSpec.Ports[].Endpoint

### DIFF
--- a/examples/all/web.yaml
+++ b/examples/all/web.yaml
@@ -23,8 +23,7 @@ services:
   ports:
   - port: 8080
     targetPort: 80
-  rules:
-  - host: minikube.local
+    endpoint: minikube.local
 configData:
   WORDPRESS_DB_NAME: wordpress
   WORDPRESS_DB_HOST: "database:3306"

--- a/examples/allnomagic/web.yaml
+++ b/examples/allnomagic/web.yaml
@@ -41,6 +41,8 @@ services:
   ports:
   - port: 8080
     targetPort: 80
+ingress:
+- name: wordpress-ingress
   rules:
   - host: minikube.local
     http:

--- a/examples/ingress/README.md
+++ b/examples/ingress/README.md
@@ -5,27 +5,24 @@ See the following snippet from [web.yaml](web.yaml).
 ```yaml
 services:
 - name: wordpress
-  type: LoadBalancer
   ports:
   - port: 8080
     targetPort: 80
-  rules:
-  - host: minikube.local
+    endpoint: minikube.local
 ```
 
-Services here is the mix of [`service` spec](https://kubernetes.io/docs/api-reference/v1.6/#servicespec-v1-core) and [`ingress` spec](https://kubernetes.io/docs/api-reference/v1.6/#ingressspec-v1beta1-extensions). So if you want a service to be exposed via an ingress set the service `type` to be `LoadBalancer`. Then also define `rules` section.
+Services here is an extension of [`service` spec](https://kubernetes.io/docs/api-reference/v1.6/#servicespec-v1-core), such that the `ServicePort` struct is extended with an `endpoint` field.  So if you want a service to be exposed via an ingress set the `endpoint` field in the format `ingress_host/ingress_path`.
 
-In `rules` section is similar to the way you define the rules in actual ingress object. If you have only one port and only one rule defined with host then the rest of the rule will be populated for you. But if you have more than one ports or more than one rule then you will also have to define the `http` section in the `rule`.
-
-So the above section gets converted to following and a service:
+When the `convert` command is run against this file, we can see that an ingress resource is populated automatically with the following parameters -
 
 ```yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  creationTimestamp: null
   labels:
     app: web
-  name: wordpress
+  name: wordpress-8080
 spec:
   rules:
   - host: minikube.local
@@ -34,7 +31,22 @@ spec:
       - backend:
           serviceName: wordpress
           servicePort: 8080
-        path: /
+        path: /foo
+status:
+  loadBalancer: {}
 ```
 
-See that the http section has been populated automatically. Because this app has only one port and only one rule.
+A valid `Ingress` resource can also be specified at the rool level of the spec, like we see in the web.yaml,
+
+```yaml
+ingress:
+- name: root-ingress
+  rules:
+  - host: minikube.external
+    http:
+      paths:
+      - backend:
+          serviceName: wordpress
+          servicePort: 8080
+        path: /
+```

--- a/examples/ingress/web.yaml
+++ b/examples/ingress/web.yaml
@@ -13,9 +13,18 @@ containers:
     value: wordpress
 services:
 - name: wordpress
-  type: LoadBalancer
   ports:
   - port: 8080
     targetPort: 80
+    endpoint: minikube.local/foo
+ingress:
+- name: root-ingress
   rules:
-  - host: minikube.local
+  - host: minikube.external
+    http:
+      paths:
+      - backend:
+          serviceName: wordpress
+          servicePort: 8080
+        path: /
+

--- a/examples/simplest/httpd.yaml
+++ b/examples/simplest/httpd.yaml
@@ -3,9 +3,7 @@ containers:
 - image: centos/httpd
 services:
 - name: httpd
-  type: LoadBalancer
   ports:
   - port: 8080
     targetPort: 80
-  rules:
-  - host: minikube.local
+    endpoint: minikube.local

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -11,9 +11,21 @@ type PersistentVolume struct {
 	Size                             string `json:"size"`
 }
 
-type Service struct {
-	Name                    string `json:"name,omitempty"`
-	api_v1.ServiceSpec      `json:",inline"`
+type ServicePortMod struct {
+	api_v1.ServicePort `json:",inline"`
+	// Endpoint allows specifying an ingress resource in the format
+	// `<Host>/<Path>`
+	Endpoint           string `json:"endpoint"`
+}
+
+type ServiceSpecMod struct {
+	api_v1.ServiceSpec `json:",inline"`
+	Name               string           `json:"name,omitempty"`
+	Ports              []ServicePortMod `json:"ports"`
+}
+
+type IngressSpecMod struct {
+	Name                    string `json:"name"`
 	ext_v1beta1.IngressSpec `json:",inline"`
 }
 
@@ -28,7 +40,8 @@ type App struct {
 	Labels            map[string]string  `json:"labels,omitempty"`
 	PersistentVolumes []PersistentVolume `json:"persistentVolumes,omitempty"`
 	ConfigData        map[string]string  `json:"configData,omitempty"`
-	Services          []Service          `json:"services,omitempty"`
+	Services          []ServiceSpecMod   `json:"services,omitempty"`
 	Containers        []Container        `json:"containers,omitempty"`
+	Ingress           []IngressSpecMod   `json:"ingress,omitempty"`
 	api_v1.PodSpec    `json:",inline"`
 }


### PR DESCRIPTION
This commit allows specifying a root level "ingress" field which
allows specifying an IngressSpec resource, plus a Name field for
the name of the ingress.

This also adds a _shortcut_ "endpoint" in
"services[].ports[].endpoint" which is essentially an extension of
"ServiceSpec.Ports[]" which allows specifying the Ingress' Host
and Path in the form "ingress_host/ingress_path", and an Ingress
resource is automatically generated based on the Service Port.

The name of the resulting Ingress is
"ServiceName-ServicePort.Port"

Fixes #22