### PR TITLE
populate name if one service specified, add tests

### DIFF
--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -17,6 +17,9 @@ func Decode(data []byte) (*spec.App, error) {
 		return nil, errors.Wrap(err, "could not unmarshal into internal struct")
 	}
 	log.Debugf("object unmrashalled: %#v\n", app)
+	if err := fixApp(&app); err != nil {
+		return nil, errors.Wrapf(err, "Unable to fix app: %v", app.Name)
+	}
 	return &app, nil
 
 }

--- a/pkg/encoding/encoding_test.go
+++ b/pkg/encoding/encoding_test.go
@@ -1,0 +1,44 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/surajssd/kapp/pkg/encoding/fixtures"
+	"github.com/surajssd/kapp/pkg/spec"
+
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		Name string
+		Data []byte
+		App  *spec.App
+	}{
+		{
+			Name: "One container mentioned in the spec",
+			Data: fixtures.SingleContainer,
+			App:  &fixtures.SingleContainerApp,
+		},
+		{
+			Name: "One persistent volume mentioned in the spec",
+			Data: fixtures.SinglePersistentVolume,
+			App:  &fixtures.SinglePersistentVolumeApp,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			app, err := Decode(test.Data)
+			if err != nil {
+				t.Fatalf("Unable to run Decode(), and error occurred: %v", err)
+			}
+
+			if !reflect.DeepEqual(test.App, app) {
+				t.Fatalf("Expected:\n%v\nGot:\n%v", spew.Sprint(test.App), spew.Sprint(app))
+			}
+		})
+	}
+}

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -1,0 +1,49 @@
+package encoding
+
+import (
+	"github.com/pkg/errors"
+	"github.com/surajssd/kapp/pkg/spec"
+)
+
+func fixApp(app *spec.App) error {
+
+	// fix app.Services
+	if err := fixServices(app); err != nil {
+		return errors.Wrap(err, "Unable to fix services")
+	}
+
+	// fix app.PersistentVolumes
+	if err := fixPersistentVolumes(app); err != nil {
+		return errors.Wrap(err, "Unable to fix persistentVolume")
+	}
+
+	return nil
+}
+
+func fixServices(app *spec.App) error {
+	for i, service := range app.Services {
+		if service.Name == "" {
+			if len(app.Services) == 1 {
+				service.Name = app.Name
+			} else {
+				return errors.New("More than one service mentioned, please specify name for each one")
+			}
+		}
+		app.Services[i] = service
+	}
+	return nil
+}
+
+func fixPersistentVolumes(app *spec.App) error {
+	for i, pVolume := range app.PersistentVolumes {
+		if pVolume.Name == "" {
+			if len(app.PersistentVolumes) == 1 {
+				pVolume.Name = app.Name
+			} else {
+				return errors.New("More than one persistent volume mentioned, please specify name for each one")
+			}
+		}
+		app.PersistentVolumes[i] = pVolume
+	}
+	return nil
+}

--- a/pkg/encoding/fixtures/single_container.go
+++ b/pkg/encoding/fixtures/single_container.go
@@ -1,0 +1,10 @@
+package fixtures
+
+var SingleContainer []byte = []byte(
+	`name: test
+containers:
+ - image: nginx
+services:
+  - ports:
+    - port: 8080
+`)

--- a/pkg/encoding/fixtures/single_container_app.go
+++ b/pkg/encoding/fixtures/single_container_app.go
@@ -1,0 +1,29 @@
+package fixtures
+
+import (
+	"github.com/surajssd/kapp/pkg/spec"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var SingleContainerApp spec.App = spec.App{
+	Name: "test",
+	Containers: []spec.Container{
+		{
+			Container: api_v1.Container{
+				Image: "nginx",
+			},
+		},
+	},
+	Services: []spec.ServiceSpecMod{
+		{
+			Name: "test",
+			Ports: []spec.ServicePortMod{
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8080,
+					},
+				},
+			},
+		},
+	},
+}

--- a/pkg/encoding/fixtures/single_persistent_volume.go
+++ b/pkg/encoding/fixtures/single_persistent_volume.go
@@ -1,0 +1,12 @@
+package fixtures
+
+var SinglePersistentVolume []byte = []byte(
+	`name: test
+containers:
+ - image: nginx
+services:
+  - ports:
+    - port: 8080
+persistentVolumes:
+- size: 500Mi
+`)

--- a/pkg/encoding/fixtures/single_persistent_volume_app.go
+++ b/pkg/encoding/fixtures/single_persistent_volume_app.go
@@ -1,0 +1,35 @@
+package fixtures
+
+import (
+	"github.com/surajssd/kapp/pkg/spec"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var SinglePersistentVolumeApp spec.App = spec.App{
+	Name: "test",
+	Containers: []spec.Container{
+		{
+			Container: api_v1.Container{
+				Image: "nginx",
+			},
+		},
+	},
+	Services: []spec.ServiceSpecMod{
+		{
+			Name: "test",
+			Ports: []spec.ServicePortMod{
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8080,
+					},
+				},
+			},
+		},
+	},
+	PersistentVolumes: []spec.PersistentVolume{
+		{
+			Name: "test",
+			Size: "500Mi",
+		},
+	},
+}

--- a/pkg/transform/fixtures/single_container_object.go
+++ b/pkg/transform/fixtures/single_container_object.go
@@ -1,0 +1,16 @@
+package fixtures
+
+import api_v1 "k8s.io/client-go/pkg/api/v1"
+
+var SingleContainerService *api_v1.Service = &api_v1.Service{
+	ObjectMeta: api_v1.ObjectMeta{
+		Name: "test",
+	},
+	Spec: api_v1.ServiceSpec{
+		Ports: []api_v1.ServicePort{
+			{
+				Port: 8080,
+			},
+		},
+	},
+}

--- a/pkg/transform/kubernetes/kubernetes_test.go
+++ b/pkg/transform/kubernetes/kubernetes_test.go
@@ -1,0 +1,40 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"reflect"
+
+	encodingFixtures "github.com/surajssd/kapp/pkg/encoding/fixtures"
+	"github.com/surajssd/kapp/pkg/spec"
+	transformFixtures "github.com/surajssd/kapp/pkg/transform/fixtures"
+	"k8s.io/client-go/pkg/runtime"
+)
+
+func TestCreateServices(t *testing.T) {
+	tests := []struct {
+		Name    string
+		App     *spec.App
+		Objects []runtime.Object
+	}{
+		{
+			"Single container specified",
+			&encodingFixtures.SingleContainerApp,
+			append(make([]runtime.Object, 0), transformFixtures.SingleContainerService),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			object, err := createServices(test.App)
+			if err != nil {
+				t.Fatalf("Creating services failed: %v", err)
+			}
+			if !reflect.DeepEqual(test.Objects, object) {
+				t.Fatalf("Expected:\n%v\nGot:\n%v", test.Objects, object)
+			}
+		})
+	}
+}
+
+// TODO: add test for auto naming of single persistent volume


### PR DESCRIPTION
If only one root level service is defined, then the resulting
Kubernetes service will have the name populated as the root level
name field.

The same is being done in case of root level persistent volume.

Also, tests have been added for this behavior.