### PR TITLE
Deploy command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	pkgcmd "github.com/surajssd/kapp/pkg/cmd"
+)
+
+// Variables
+var (
+	DeployFiles []string
+)
+
+// convertCmd represents the convert command
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Deploy an application to Kubernetes cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := pkgcmd.Deploy(DeployFiles); err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
+	},
+}
+
+func init() {
+	deployCmd.Flags().StringArrayVarP(&DeployFiles, "files", "f", []string{}, "Specify files")
+	RootCmd.AddCommand(deployCmd)
+}

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+
+	"github.com/surajssd/kapp/pkg/encoding"
+	"github.com/surajssd/kapp/pkg/transform/kubernetes"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+)
+
+func Deploy(files []string) error {
+	for _, file := range files {
+
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return errors.Wrap(err, "file reading failed")
+		}
+
+		app, err := encoding.Decode(data)
+		if err != nil {
+			return errors.Wrap(err, "unable to unmarshal data")
+		}
+
+		ros, err := kubernetes.Transform(app)
+		if err != nil {
+			return errors.Wrap(err, "unable to convert data")
+		}
+
+		for _, o := range ros {
+			data, err := yaml.Marshal(o)
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal object")
+			}
+
+			cmd := exec.Command("kubectl", "create", "-f", "-")
+
+			stdin, err := cmd.StdinPipe()
+			if err != nil {
+				return errors.Wrap(err, "can't get stdinPipe for kubectl")
+			}
+
+			go func() {
+				defer stdin.Close()
+				_, err := io.WriteString(stdin, string(data))
+				if err != nil {
+					fmt.Printf("can't write to stdin %v\n", err)
+				}
+			}()
+
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				fmt.Printf("%s", string(out))
+				return errors.Wrap(err, "failed to execute command")
+			}
+			fmt.Printf("%s", string(out))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Originally I wanted to use k8s.io/client-go to do this. So we don't have to depend on the external binary.

I've been fighting with k8s.io/client-go  for almost 2 days, and didn't get much progress. It will require a lot of code change to make this done using k8s.io/client-go in some sensible way.

To get this moving I've used 'exec' and call  `kubectl` binary.

