### PR TITLE
Auto populating port names, if not specified

### DIFF
--- a/pkg/encoding/encoding_test.go
+++ b/pkg/encoding/encoding_test.go
@@ -27,6 +27,26 @@ func TestDecode(t *testing.T) {
 			Data: fixtures.SinglePersistentVolume,
 			App:  &fixtures.SinglePersistentVolumeApp,
 		},
+		{
+			Name: "Multiple ports specified with any names",
+			Data: fixtures.MultiplePortsNoNames,
+			App:  &fixtures.MultiplePortsNoNamesApp,
+		},
+		{
+			Name: "Multiple ports, some with names specified, others with no names",
+			Data: fixtures.MultiplePortsWithAndWithoutNames,
+			App:  &fixtures.MultiplePortsWithAndWithoutNamesApp,
+		},
+		{
+			Name: "Multiple ports, all with names",
+			Data: fixtures.MultiplePortsWithNames,
+			App:  &fixtures.MultiplePortsWithNamesApp,
+		},
+		{
+			Name: "Single port, without any name",
+			Data: fixtures.SinglePortWithoutName,
+			App:  &fixtures.SinglePortWithoutNameApp,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"github.com/pkg/errors"
 	"github.com/surajssd/kapp/pkg/spec"
+	"strconv"
 )
 
 func fixApp(app *spec.App) error {
@@ -22,6 +23,7 @@ func fixApp(app *spec.App) error {
 
 func fixServices(app *spec.App) error {
 	for i, service := range app.Services {
+		// auto populate service name if only one service is specified
 		if service.Name == "" {
 			if len(app.Services) == 1 {
 				service.Name = app.Name
@@ -30,6 +32,14 @@ func fixServices(app *spec.App) error {
 			}
 		}
 		app.Services[i] = service
+
+		for i, servicePort := range service.Ports {
+			// auto populate port names if not specified
+			if len(service.Ports) > 1 && servicePort.Name == "" {
+				servicePort.Name = service.Name + "-" + strconv.FormatInt(int64(servicePort.Port), 10)
+			}
+			service.Ports[i] = servicePort
+		}
 	}
 	return nil
 }

--- a/pkg/encoding/fixtures/multiple_ports_no_names.go
+++ b/pkg/encoding/fixtures/multiple_ports_no_names.go
@@ -1,0 +1,13 @@
+package fixtures
+
+var MultiplePortsNoNames []byte = []byte(
+	`name: test
+containers:
+ - image: nginx
+services:
+- name: nginx
+  ports:
+  - port: 8080
+  - port: 8081
+  - port: 8082
+`)

--- a/pkg/encoding/fixtures/multiple_ports_no_names_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_no_names_app.go
@@ -1,0 +1,42 @@
+package fixtures
+
+import (
+	"github.com/surajssd/kapp/pkg/spec"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var MultiplePortsNoNamesApp spec.App = spec.App{
+	Name: "test",
+	Containers: []spec.Container{
+		{
+			Container: api_v1.Container{
+				Image: "nginx",
+			},
+		},
+	},
+	Services: []spec.ServiceSpecMod{
+		{
+			Name: "nginx",
+			Ports: []spec.ServicePortMod{
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8080,
+						Name: "nginx-8080",
+					},
+				},
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8081,
+						Name: "nginx-8081",
+					},
+				},
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8082,
+						Name: "nginx-8082",
+					},
+				},
+			},
+		},
+	},
+}

--- a/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without.go
+++ b/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without.go
@@ -1,0 +1,15 @@
+package fixtures
+
+var MultiplePortsWithAndWithoutNames []byte = []byte(
+	`name: test
+containers:
+ - image: nginx
+services:
+- ports:
+  - port: 8080
+    name: port-1
+  - port: 8081
+    name: port-2
+  - port: 8082
+  - port: 8083
+`)

--- a/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without_app.go
@@ -1,0 +1,48 @@
+package fixtures
+
+import (
+	"github.com/surajssd/kapp/pkg/spec"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var MultiplePortsWithAndWithoutNamesApp spec.App = spec.App{
+	Name: "test",
+	Containers: []spec.Container{
+		{
+			Container: api_v1.Container{
+				Image: "nginx",
+			},
+		},
+	},
+	Services: []spec.ServiceSpecMod{
+		{
+			Name: "test",
+			Ports: []spec.ServicePortMod{
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8080,
+						Name: "port-1",
+					},
+				},
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8081,
+						Name: "port-2",
+					},
+				},
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8082,
+						Name: "test-8082",
+					},
+				},
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8083,
+						Name: "test-8083",
+					},
+				},
+			},
+		},
+	},
+}

--- a/pkg/encoding/fixtures/multiple_ports_with_names.go
+++ b/pkg/encoding/fixtures/multiple_ports_with_names.go
@@ -1,0 +1,15 @@
+package fixtures
+
+var MultiplePortsWithNames []byte = []byte(
+	`name: test
+containers:
+ - image: nginx
+services:
+- ports:
+  - port: 8080
+    name: port-1
+  - port: 8081
+    name: port-2
+  - port: 8082
+    name: port-3
+`)

--- a/pkg/encoding/fixtures/multiple_ports_with_names_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_with_names_app.go
@@ -1,0 +1,42 @@
+package fixtures
+
+import (
+	"github.com/surajssd/kapp/pkg/spec"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var MultiplePortsWithNamesApp spec.App = spec.App{
+	Name: "test",
+	Containers: []spec.Container{
+		{
+			Container: api_v1.Container{
+				Image: "nginx",
+			},
+		},
+	},
+	Services: []spec.ServiceSpecMod{
+		{
+			Name: "test",
+			Ports: []spec.ServicePortMod{
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8080,
+						Name: "port-1",
+					},
+				},
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8081,
+						Name: "port-2",
+					},
+				},
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8082,
+						Name: "port-3",
+					},
+				},
+			},
+		},
+	},
+}

--- a/pkg/encoding/fixtures/single_port_without_name.go
+++ b/pkg/encoding/fixtures/single_port_without_name.go
@@ -1,0 +1,10 @@
+package fixtures
+
+var SinglePortWithoutName []byte = []byte(
+	`name: test
+containers:
+ - image: nginx
+services:
+- ports:
+  - port: 8080
+`)

--- a/pkg/encoding/fixtures/single_port_without_name_app.go
+++ b/pkg/encoding/fixtures/single_port_without_name_app.go
@@ -1,0 +1,29 @@
+package fixtures
+
+import (
+	"github.com/surajssd/kapp/pkg/spec"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var SinglePortWithoutNameApp spec.App = spec.App{
+	Name: "test",
+	Containers: []spec.Container{
+		{
+			Container: api_v1.Container{
+				Image: "nginx",
+			},
+		},
+	},
+	Services: []spec.ServiceSpecMod{
+		{
+			Name: "test",
+			Ports: []spec.ServicePortMod{
+				{
+					ServicePort: api_v1.ServicePort{
+						Port: 8080,
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
Before this commit, if a definition is passed with multiple ports
in one service, then in the generated Kubernetes output, the port
names are not populated, which when deployed to a Kubernetes
cluster, throws an error.

This commit fixes this, such that if multiple ports for one
service are specified, then if the port names are not specified,
they are auto generated and populated, in the format -
"service_name-service_port"

Note that, the auto generation and population only happens in
case of multiple ports, and in the case when the port names
are not already specified.

e.g. - for the input -
```yaml
name: test
containers:
 - image: nginx
services:
- name: nginx
  ports:
  - port: 8080
  - port: 8081
```
the resulting output will contain Kubernetes service as -
```yaml
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    app: test
  name: nginx
spec:
  ports:
  - name: nginx-8080
    port: 8080
    targetPort: 0
  - name: nginx-8081
    port: 8081
    targetPort: 0
  selector:
    app: test
```
This commit also adds tests for this behavior.

Fix #38