### PR TITLE
add support for defining multiple apps in one file

### DIFF
--- a/examples/single_file/wordpress.yml
+++ b/examples/single_file/wordpress.yml
@@ -1,0 +1,32 @@
+name: database
+containers:
+- image: mariadb:10
+  env:
+  - name: MYSQL_ROOT_PASSWORD
+    value: rootpasswd
+  - name: MYSQL_DATABASE
+    value: wordpress
+  - name: MYSQL_USER
+    value: wordpress
+  - name: MYSQL_PASSWORD
+    value: wordpress
+services:
+- ports:
+  - port: 3306
+---
+name: wordpress
+containers:
+- image: wordpress:4
+  env:
+  - name: WORDPRESS_DB_HOST
+    value: database:3306
+  - name: WORDPRESS_DB_PASSWORD
+    value: wordpress
+  - name: WORDPRESS_DB_USER
+    value: wordpress
+  - name: WORDPRESS_DB_NAME
+    value: wordpress
+services:
+- ports:
+  - port: 8080
+    targetPort: 80

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/surajssd/kapp/pkg/encoding"
 	"github.com/surajssd/kapp/pkg/transform/kubernetes"
@@ -15,12 +17,42 @@ import (
 
 func Generate(files []string) error {
 
+	var appData [][]byte
 	for _, file := range files {
 
 		data, err := ioutil.ReadFile(file)
 		if err != nil {
 			return errors.Wrap(err, "file reading failed")
 		}
+
+		// The regular expression takes care of when triple dashes are in the
+		// starting of the file or when they are as a separate line somewhere
+		// in the middle of the file or at the end. Ideally this should be taken
+		// care by the yaml library since this is valid YAML syntax anyway,
+		// but right now neither the go-yaml/yaml (issue #232) nor the one
+		// that we use supports the multiple document structure, so yeah!
+		apps := regexp.MustCompile("(^|\n)---\n").Split(string(data), -1)
+		for _, app := range apps {
+			// strings.TrimSpace will remove all the extra whitespaces and
+			// newline characters, and then proceed only when the length of the
+			// string is more than 0
+			// this avoids passing empty input further in the program in cases
+			// like -
+			// ---			# avoids empty input here
+			// ---
+			// name: abc
+			// containers:
+			// ...
+			// ---
+			//				# avoids empty input here
+			// ---			# avoids empty input here
+			if len(strings.TrimSpace(app)) > 0 {
+				appData = append(appData, []byte(app))
+			}
+		}
+	}
+
+	for _, data := range appData {
 
 		app, err := encoding.Decode(data)
 		if err != nil {


### PR DESCRIPTION
Before this commit, every application had to be defined in a
separate file, and while deploying, had to be passed to the CLI
like `kapp covert -f app1.yml -f app2.yml`.

In this commit, support for defining multiple applications in one
file separated by triple dashes has been added, which means that
Kubernetes artifacts for all the applications defined in a given
file will be generated.

A sample application defined like this will look like -

```yaml
name: database
containers:
- image: mariadb:10
services:
- ports:
  - port: 3306
---
name: wordpress
containers:
- image: wordpress:4
services:
- ports:
  - port: 8080
    targetPort: 80
```

This commit also adds an example for this behavior.

Fix #17